### PR TITLE
Dynamically Add Markers to SVG Map

### DIFF
--- a/map.html
+++ b/map.html
@@ -27,31 +27,21 @@
     </style>
 </head>
 <body>
+    <!-- Holds the panorama. Controlled by the pannellum library -->
+    <div id="panorama"></div>
 
-<div id="panorama"></div>
-<div id="map"><div>
+    <!-- Holds the SVG map. Controlled by the custom map.js application -->
+    <div id="map">
+        <object id="mapsvg" data="map.svg" type="image/svg+xml"></object>
+    <div>
 
-<script>
-$.getJSON('tour.json', function(tour) {
-  console.log("loaded data", tour);
-  var config = tour;
-
-  $(document).ready(function() {
-    var viewer = pannellum.viewer('panorama', config);
-    console.log("Pannellum viewer: ", viewer);
-
-    viewer.on('load', function() {
-      console.log("Loaded pannellum.");
+    <!-- Custom JS to connect the panorama to the map -->
+    <script type="text/javascript" src="map.js"></script>
+    <script type="text/javascript">
+    App.run({
+        panoramaConfig: 'tour.json',
+        mapSvgId: "mapsvg",
     });
-
-    viewer.on('scenechange', function(sceneId) {
-      console.log("Scene: " + sceneId, "Pitch: " + viewer.getPitch(), "Yaw: " + viewer.getYaw(), "Config: ", viewer.getConfig());
-      $("#map").html("Map for scene:<br><b>"+sceneId+"</b>");
-    });
-
-  });
-});
-</script>
-
+    </script>
 </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -21,8 +21,6 @@
       width: 150px;
       height: 390px;
       background-color: #fff;
-      background-image: url("map.svg");
-      background-size: cover;
     }
     </style>
 </head>

--- a/map.js
+++ b/map.js
@@ -78,7 +78,7 @@ window.App = (function($, pannellum) {
 			shape.setAttributeNS(null, "fill", "red");
 			svg.appendChild(shape);
 			self.svgMarker = shape;
-			}
+		}
 	};
 	App.prototype.showSvgMarker = function(display) {
 		if(self.svgMarker) {

--- a/map.js
+++ b/map.js
@@ -78,7 +78,7 @@ window.App = (function($, pannellum) {
 			shape.setAttributeNS(null, "fill", "red");
 			svg.appendChild(shape);
 			self.svgMarker = shape;
-        }
+			}
 	};
 	App.prototype.showSvgMarker = function(display) {
 		if(self.svgMarker) {

--- a/map.js
+++ b/map.js
@@ -1,0 +1,90 @@
+window.App = (function($, pannellum) {
+	"use strict";
+
+	var App = function(config) {
+		this.config = config || {};
+		this.config.mapSvgId = this.config.mapSvgId || 'mapsvg';
+		this.config.panoramaConfig - this.config.panoramaConfig || 'tour.json';
+		this.panoramaData = null;
+		this.panoramaSceneId = null;
+		this.onDocumentLoaded = this.onDocumentLoaded.bind(this);
+	};
+	App.run = function(config) {
+		var app = new App(config);
+		app.run();
+	};
+	App.prototype.run = function() {
+		var self = this;
+		$.getJSON(this.config.panoramaConfig, function(data) {
+			self.panoramaData = data;
+			self.panoramaSceneId = data.default.firstScene;
+			$(document).ready(self.onDocumentLoaded);
+		});
+	};
+	App.prototype.error = function() {
+		console.error("Error: ", arguments);
+	};
+	App.prototype.onDocumentLoaded = function() {
+		this.viewer = pannellum.viewer('panorama', this.panoramaData);
+		this.listenForEvents();
+	};
+	App.prototype.listenForEvents = function() {
+		var self = this;
+		var viewer = this.viewer;
+		var mapSvgId = this.config.mapSvgId;
+
+		viewer.on('load', function() {
+			console.log("Loaded pannellum.", viewer);
+		});
+		viewer.on('scenechange', function(sceneId) {
+			self.panoramaSceneId = sceneId;
+			self.updateSvg();
+		});
+
+		document.getElementById(mapSvgId).addEventListener("load", function() {
+			self.svgDocument = this.getSVGDocument();
+			console.log("SVG Loaded: ", self.svgDocument);
+			console.dir(self.svgDocument);
+			self.updateSvg();
+		});
+	};
+	App.prototype.updateSvg = function() {
+		var self = this;
+		var scene = this.panoramaData.scenes[this.panoramaSceneId];
+		var position;
+		console.log("Map settings for scene ", this.panoramaSceneId, scene.map);
+		if ('map' in scene) {
+			position = scene.map.position.split(",");
+			self.drawSvgMarker({ x: position[0], y: position[1] });
+		} else {
+			self.showSvgMarker(false);
+		}
+	};
+	App.prototype.drawSvgMarker = function(params) {
+		var svgDocument = this.svgDocument;
+		var svg = svgDocument.documentElement;
+		var svgNamespace = "http://www.w3.org/2000/svg";
+		var shape;
+
+		if(self.svgMarker) {
+			shape = self.svgMarker;
+			shape.setAttributeNS(null, "cx", params.x);
+			shape.setAttributeNS(null, "cy", params.y);
+		} else {
+            shape = svgDocument.createElementNS(svgNamespace, "circle");
+			shape.setAttributeNS(null, "cx", params.x);
+			shape.setAttributeNS(null, "cy", params.y);
+			shape.setAttributeNS(null, "r",  15);
+			shape.setAttributeNS(null, "fill", "red");
+			svg.appendChild(shape);
+            self.svgMarker = shape;
+        }
+	};
+	App.prototype.showSvgMarker = function(display) {
+		if(self.svgMarker) {
+			self.svgMarker.setAttributeNS(null, "display", display ? "" : "none");
+		}
+	}
+
+	return App;
+})(jQuery, pannellum);

--- a/map.js
+++ b/map.js
@@ -71,20 +71,20 @@ window.App = (function($, pannellum) {
 			shape.setAttributeNS(null, "cx", params.x);
 			shape.setAttributeNS(null, "cy", params.y);
 		} else {
-            shape = svgDocument.createElementNS(svgNamespace, "circle");
+			shape = svgDocument.createElementNS(svgNamespace, "circle");
 			shape.setAttributeNS(null, "cx", params.x);
 			shape.setAttributeNS(null, "cy", params.y);
 			shape.setAttributeNS(null, "r",  15);
 			shape.setAttributeNS(null, "fill", "red");
 			svg.appendChild(shape);
-            self.svgMarker = shape;
+			self.svgMarker = shape;
         }
 	};
 	App.prototype.showSvgMarker = function(display) {
 		if(self.svgMarker) {
 			self.svgMarker.setAttributeNS(null, "display", display ? "" : "none");
 		}
-	}
+	};
 
 	return App;
 })(jQuery, pannellum);

--- a/map.js
+++ b/map.js
@@ -4,7 +4,7 @@ window.App = (function($, pannellum) {
 	var App = function(config) {
 		this.config = config || {};
 		this.config.mapSvgId = this.config.mapSvgId || 'mapsvg';
-		this.config.panoramaConfig - this.config.panoramaConfig || 'tour.json';
+		this.config.panoramaConfig = this.config.panoramaConfig || 'tour.json';
 		this.panoramaData = null;
 		this.panoramaSceneId = null;
 		this.onDocumentLoaded = this.onDocumentLoaded.bind(this);

--- a/map.js
+++ b/map.js
@@ -56,9 +56,8 @@ window.App = (function($, pannellum) {
 		if ('map' in scene) {
 			position = scene.map.position.split(",");
 			self.drawSvgMarker({ x: position[0], y: position[1] });
-		} else {
-			self.showSvgMarker(false);
 		}
+		self.showSvgMarker('map' in scene);
 	};
 	App.prototype.drawSvgMarker = function(params) {
 		var svgDocument = this.svgDocument;

--- a/tour.json
+++ b/tour.json
@@ -26,7 +26,10 @@
                     "text": "Formal Entrance",
                     "sceneId": "lu_fam-formal_entrance"
                 }
-            ]
+            ],
+            "map": {
+                "position": "420,730"
+            }
         },
 
         "lu_fam-formal_entrance": {
@@ -50,7 +53,10 @@
                     "sceneId": "lu_fam-street_to_compound"
                 }
 
-            ]
+            ],
+            "map": {
+                "position": "400,600"
+            }
         },
 
         "lu_fam-daifu_di": {


### PR DESCRIPTION
@bilbe This is an example of how you might dynamically update the SVG to associate the panorama scene with a position on the map. For simplicity, I used a circle as the marker and pure DOM manipulation.

In addition to updating the JS, I added the following "map" keys to scenes in the `tour.json`:

```json
"lu_fam-street_to_compound": {
    "title": "Street to Lu Family Compound",
    "hotSpots": [ /*...*/ ],
    "map": {
        "position": "420,730"
    }
},
"lu_fam-formal_entrance": {
    "title": "Lu Family Compound, Formal Entrance",
    "hotSpots": [ /*...*/ ],
    "map": {
        "position": "400,600"
    }
```

The `position: "400,600"` specifies the x,y coordinate of the marker on the SVG and the JS takes care of the rest.